### PR TITLE
enhance(policy): Remove input.data and use input.body

### DIFF
--- a/examples/policy/transmit.rego
+++ b/examples/policy/transmit.rego
@@ -6,16 +6,16 @@ slack contains {
     "title": "Hello",
     "emoji": ":wave:",
     "channel": "#github-notify",
-    "body": input.data,
+    "body": input.body,
 } if {
-    is_string(input.data)
+    is_string(input.body)
 }
 
 slack contains {
     "title": "Hello",
     "emoji": ":wave:",
     "channel": "#github-notify",
-    "body": json.marshal(input.data),
+    "body": json.marshal(input.body),
 } if {
-    is_object(input.data)
+    is_object(input.body)
 }

--- a/pkg/controller/http/github_actions.go
+++ b/pkg/controller/http/github_actions.go
@@ -81,8 +81,7 @@ func handleGitHubActions(r *http.Request, uc interfaces.UseCases) error {
 		Source: "github.actions",
 		Schema: "actions",
 		Header: cloneHeader(r.Header),
-		Body:   body,
-		Data:   payload,
+		Body:   payload,
 		Auth: model.AuthContext{
 			GitHub: &model.AuthContextGitHub{
 				Actions: claims,

--- a/pkg/controller/http/github_webhook.go
+++ b/pkg/controller/http/github_webhook.go
@@ -28,8 +28,7 @@ func handleGitHubWebhook(r *http.Request, uc interfaces.UseCases, secret string)
 	msg := model.Message{
 		Source: "github.webhook",
 		Schema: r.Header.Get("X-GitHub-Event"),
-		Data:   event,
-		Body:   payload,
+		Body:   event,
 		Header: cloneHeader(r.Header),
 		Auth: model.AuthContext{
 			GitHub: &model.AuthContextGitHub{

--- a/pkg/controller/http/github_webhook_test.go
+++ b/pkg/controller/http/github_webhook_test.go
@@ -111,7 +111,7 @@ func TestHandleGitHubWebhook(t *testing.T) {
 						gt.Equal(t, auth.Valid, true)
 					}
 
-					data := v.Msg.Data.(*github.IssuesEvent)
+					data := v.Msg.Body.(*github.IssuesEvent)
 					gt.NotEqual(t, data, nil)
 					gt.NotEqual(t, data.Action, nil)
 					gt.Equal(t, *data.Action, "opened")

--- a/pkg/controller/http/pubsub.go
+++ b/pkg/controller/http/pubsub.go
@@ -70,11 +70,11 @@ func handlePubSubMessage(r *http.Request, uc interfaces.UseCases) error {
 	// Pub/Sub message data is free format. If it can be parsed as JSON, it will be stored in msg.Data
 	var data any
 	if err := json.Unmarshal(pubsubMsg.Message.Data, &data); err == nil {
-		msg.Data = data
+		msg.Body = data
 		logger.Debug("Parsed data of Pub/Sub as JSON", "data", data)
 	} else {
-		msg.Data = string(pubsubMsg.Message.Data)
-		logger.Debug("Data of Pub/Sub can not be parsed, use it as raw", "data", msg.Data)
+		msg.Body = string(pubsubMsg.Message.Data)
+		logger.Debug("Data of Pub/Sub can not be parsed, use it as raw", "data", pubsubMsg.Message.Data)
 	}
 
 	// Extract Google ID token from Authorization header. Empty Authorization header is allowed, but ID token validation error is not allowed and return error.

--- a/pkg/controller/http/pubsub_test.go
+++ b/pkg/controller/http/pubsub_test.go
@@ -41,7 +41,7 @@ func TestPubSubJSON(t *testing.T) {
 		Ctx context.Context
 		Msg model.Message
 	}) {
-		msg := gt.Cast[map[string]any](t, v.Msg.Data)
+		msg := gt.Cast[map[string]any](t, v.Msg.Body)
 		gt.Equal(t, msg["kind"], "storage#object")
 		gt.Equal(t, v.Msg.Schema, "json_schema")
 	})
@@ -67,7 +67,7 @@ func TestPubSubText(t *testing.T) {
 		Ctx context.Context
 		Msg model.Message
 	}) {
-		msg := gt.Cast[string](t, v.Msg.Data)
+		msg := gt.Cast[string](t, v.Msg.Body)
 		gt.Equal(t, msg, "Hello, World")
 		gt.Equal(t, v.Msg.Schema, "text_schema")
 	})

--- a/pkg/controller/http/raw.go
+++ b/pkg/controller/http/raw.go
@@ -36,10 +36,10 @@ func handleRawMessage(r *http.Request, uc interfaces.UseCases) error {
 		if err := json.Unmarshal(raw, &data); err != nil {
 			return goerr.Wrap(err, "Failed to unmarshal JSON", goerr.V("data", string(raw)))
 		}
-		msg.Data = data
+		msg.Body = data
 		logger.Debug("Parsed data of Pub/Sub as JSON", "data", data)
 	} else {
-		msg.Data = string(raw)
+		msg.Body = string(raw)
 		logger.Debug("Parsed data of Pub/Sub as string", "data", string(raw))
 	}
 

--- a/pkg/domain/model/message.go
+++ b/pkg/domain/model/message.go
@@ -13,11 +13,8 @@ type Message struct {
 	// Header is HTTP header of the message.
 	Header map[string]string `json:"header"`
 
-	// Body is parsed raw HTTP body. If content-type is application/json, it's parsed as JSON. Otherwise, it's raw bytes.
+	// Body is parsed HTTP body. If content-type is application/json, it's parsed as JSON. Otherwise, it's raw bytes.
 	Body any `json:"body"`
-
-	// Data is parsed data part of the message. It's free format and can be any type. If it's JSON, it's parsed as JSON. Otherwise, it's raw bytes.
-	Data any `json:"data"`
 
 	// Auth is authentication information of the message. Authentication message is extracted from header mainly, e.g. JWT token, Secret key, etc.
 	Auth AuthContext `json:"auth"`

--- a/pkg/usecase/transmit_test.go
+++ b/pkg/usecase/transmit_test.go
@@ -34,7 +34,7 @@ func TestTransmitSlack(t *testing.T) {
 
 	msg := model.Message{
 		Schema: "for_slack",
-		Data:   "Hello, Slack",
+		Body:   "Hello, Slack",
 	}
 	gt.NoError(t, uc.Route(context.Background(), msg))
 }


### PR DESCRIPTION
Having both of `data` and `body` is confusing. Then remove `data` and use `body` only.