### PR TITLE
enhance(ctrl): Do not use parse func in GitHub sdk

### DIFF
--- a/pkg/controller/http/github_webhook.go
+++ b/pkg/controller/http/github_webhook.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"encoding/json"
 	"net/http"
 	"strconv"
 
@@ -20,15 +21,15 @@ func handleGitHubWebhook(r *http.Request, uc interfaces.UseCases, secret string)
 		secretValidated = true
 	}
 
-	event, err := github.ParseWebHook(github.WebHookType(r), payload)
-	if err != nil {
-		return goerr.Wrap(err, "Failed to parse GitHub webhook event", goerr.V("payload", string(payload)))
+	var body any
+	if err := json.Unmarshal(payload, &body); err != nil {
+		return goerr.Wrap(err, "Failed to unmarshal JSON", goerr.V("payload", string(payload)))
 	}
 
 	msg := model.Message{
 		Source: "github.webhook",
 		Schema: r.Header.Get("X-GitHub-Event"),
-		Body:   event,
+		Body:   body,
 		Header: cloneHeader(r.Header),
 		Auth: model.AuthContext{
 			GitHub: &model.AuthContextGitHub{

--- a/pkg/controller/http/github_webhook_test.go
+++ b/pkg/controller/http/github_webhook_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/google/go-github/v68/github"
 	"github.com/m-mizutani/gt"
 	http_server "github.com/m-mizutani/xroute/pkg/controller/http"
 	"github.com/m-mizutani/xroute/pkg/domain/model"
@@ -111,10 +110,9 @@ func TestHandleGitHubWebhook(t *testing.T) {
 						gt.Equal(t, auth.Valid, true)
 					}
 
-					data := v.Msg.Body.(*github.IssuesEvent)
+					data := v.Msg.Body.(map[string]interface{})
 					gt.NotEqual(t, data, nil)
-					gt.NotEqual(t, data.Action, nil)
-					gt.Equal(t, *data.Action, "opened")
+					gt.Equal(t, data["action"], "opened")
 				})
 			}
 		})


### PR DESCRIPTION
Because they don't support some event (e.g. `registry_package`, `sub_issues`)